### PR TITLE
Fixup for dbapi2 and jdbc

### DIFF
--- a/databasez/overwrites/dbapi2.py
+++ b/databasez/overwrites/dbapi2.py
@@ -25,4 +25,20 @@ class Database(SQLAlchemyDatabase):
         new_query_options = dict(database_url.options)
         if database_url_new.driver:
             new_query_options["dbapi_dsn_driver"] = database_url_new.driver
+        if "dbapi_pool" in options:
+            new_query_options["dbapi_pool"] = options.pop("dbapi_pool")
+        if "dbapi_force_async_wrapper" in options:
+            dbapi_force_async_wrapper = options.pop("dbapi_force_async_wrapper")
+            if isinstance(dbapi_force_async_wrapper, bool):
+                new_query_options["dbapi_force_async_wrapper"] = (
+                    "true" if dbapi_force_async_wrapper else "false"
+                )
+            elif dbapi_force_async_wrapper is not None:
+                new_query_options["dbapi_force_async_wrapper"] = dbapi_force_async_wrapper
+        if "dbapi_driver_args" in options:
+            dbapi_driver_args = options.pop("dbapi_driver_args")
+            if isinstance(dbapi_driver_args, str):
+                new_query_options["dbapi_driver_args"] = dbapi_driver_args
+            else:
+                new_query_options["dbapi_driver_args"] = self.json_serializer(dbapi_driver_args)
         return database_url_new.replace(driver=None, options=new_query_options), options

--- a/databasez/overwrites/jdbc.py
+++ b/databasez/overwrites/jdbc.py
@@ -47,6 +47,12 @@ class Database(SQLAlchemyDatabase):
                 else:
                     new_classpath.extend(query_classpath)
             options["classpath"] = new_classpath
+        if "jdbc_driver_args" in options:
+            jdbc_driver_args = options.pop("jdbc_driver_args")
+            if isinstance(jdbc_driver_args, str):
+                new_query_options["jdbc_driver_args"] = jdbc_driver_args
+            else:
+                new_query_options["jdbc_driver_args"] = self.json_serializer(jdbc_driver_args)
         return database_url_new.replace(driver=None, options=new_query_options), options
 
     async def connect(self, database_url: "DatabaseURL", **options: typing.Any) -> None:

--- a/docs/connections-and-transactions.md
+++ b/docs/connections-and-transactions.md
@@ -259,12 +259,12 @@ The dbapi2 driver supports some extra parameters which will be removed from the 
 
 * **dbapi_driver_args** - additional keyword arguments for the driver. Note: they must be passed in json format. Query only parameter.
 * **dbapi_dsn_driver** - If required it is possible to set the dsn driver here. Normally it should work without. You can use the same trick like in jdbc to provide a dsn driver.
+* **dbapi_pool** - thread/process. Default: thread. How the dbapi2. is isolated. Either via ProcessPool or ThreadPool (with one worker).
+* **dbapi_force_async_wrapper** - bool/None. Default: None. Figure out if the async_wrapper is required. By setting a bool the wrapper can be enforced or removed.
 
 The dbapi2 has some extra options which cannot be passed via the url, some of them are required:
 
 * **dbapi_path** - Import path of the dbapi2 module. Required
-* **dbapi_pool** - thread/process. Default: thread. How the dbapi2. is isolated. Either via ProcessPool or ThreadPool (with one worker).
-* **dbapi_force_async_wrapper** - bool/None. Default: None. Figure out if the async_wrapper is required. By setting a bool
 
 ## Transactions
 


### PR DESCRIPTION
Fixup for dbapi2 and jdbc

Changes:
- execute dbapi2 multithreaded
- improve the query/options transformation
  - driver_args are now conditionally serialized and in the query inserted
  - dbapi_pool and dbapi_force_async_wrapper are now valid query arguments for dbapi2