### PR TITLE
Hotfix for reenabling bulk-inserts

### DIFF
--- a/databasez/__init__.py
+++ b/databasez/__init__.py
@@ -1,5 +1,5 @@
 from databasez.core import Database, DatabaseURL
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 __all__ = ["Database", "DatabaseURL"]

--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -228,7 +228,7 @@ class Database:
     async def execute(
         self,
         query: typing.Union[ClauseElement, str],
-        values: typing.Optional[dict] = None,
+        values: typing.Any = None,
     ) -> typing.Union[interfaces.Record, int]:
         async with self.connection() as connection:
             return await connection.execute(query, values)

--- a/databasez/interfaces.py
+++ b/databasez/interfaces.py
@@ -183,10 +183,12 @@ class ConnectionBackend(ABC):
     ) -> typing.Any: ...
 
     @abstractmethod
-    async def execute_raw(self, stmt: typing.Any) -> typing.Any: ...
+    async def execute_raw(self, stmt: typing.Any, value: typing.Any = None) -> typing.Any: ...
 
     @abstractmethod
-    async def execute(self, stmt: typing.Any) -> typing.Union[Record, int]:
+    async def execute(
+        self, stmt: typing.Any, value: typing.Any = None
+    ) -> typing.Union[Record, int]:
         """
         Executes statement and returns the last row defaults (insert) or rowid (insert) or the row count of updates.
 

--- a/databasez/sqlalchemy.py
+++ b/databasez/sqlalchemy.py
@@ -144,16 +144,21 @@ class SQLAlchemyConnection(ConnectionBackend):
             async for batch in result.partitions():
                 yield batch
 
-    async def execute_raw(self, stmt: typing.Any) -> typing.Any:
+    async def execute_raw(self, stmt: typing.Any, value: typing.Any = None) -> typing.Any:
         connection = self.async_connection
         assert connection is not None, "Connection is not acquired"
+        if value is not None:
+            return await connection.execute(stmt, value)
         return await connection.execute(stmt)
 
-    async def execute(self, stmt: typing.Any) -> typing.Union[Record, int]:
+    async def execute(
+        self, stmt: typing.Any, value: typing.Any = None
+    ) -> typing.Union[Record, int]:
         """
         Executes statement and returns the last row defaults (insert) or rowid (insert) or the row count of updates.
         """
-        with await self.execute_raw(stmt) as result:
+
+        with await self.execute_raw(stmt, value) as result:
             if result.is_insert:
                 try:
                     if result.returned_defaults:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.8.2
+
+### Fixed
+
+- Cannot pass parameters to execute directly. Bulk_inserts not possible anymore.
+
 ## 0.8.1
 
 ### Fixed


### PR DESCRIPTION
Changes:
- fixes overly restricted execute interface (inherited). Allow multi-inserts.
- bump version.