### PR TITLE
Fix run_sync on Database & bump version

### DIFF
--- a/databasez/__init__.py
+++ b/databasez/__init__.py
@@ -1,5 +1,5 @@
 from databasez.core import Database, DatabaseURL
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 __all__ = ["Database", "DatabaseURL"]

--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -268,7 +268,7 @@ class Database:
         **kwargs: typing.Any,
     ) -> typing.Any:
         async with self.connection() as connection:
-            return connection.run_sync(fn, *args, **kwargs)
+            return await connection.run_sync(fn, *args, **kwargs)
 
     async def create_all(self, meta: MetaData, **kwargs: typing.Any) -> None:
         async with self.connection() as connection:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,7 @@
 
 - DatabaseTestClient can now use the improvements in 8.0 too.
 - DatabaseTestClient is now tested.
+- Fix run_sync on Database objects.
 
 ## 0.8.2
 


### PR DESCRIPTION
A small bug:

run_sync on db objects didn't await.

This PR contains the fix and bumps the version.