### PR TITLE
switching off force_rollback, refcounting Database connect/disconnect calls.

### DIFF
--- a/databasez/__init__.py
+++ b/databasez/__init__.py
@@ -1,5 +1,5 @@
 from databasez.core import Database, DatabaseURL
 
-__version__ = "0.8.5"
+__version__ = "0.9.0"
 
 __all__ = ["Database", "DatabaseURL"]

--- a/databasez/core/connection.py
+++ b/databasez/core/connection.py
@@ -44,7 +44,7 @@ class Connection:
                         self.connection_transaction = self.transaction(
                             existing_transaction=raw_transaction
                         )
-                        # we don't need to call __aenter__ of connection_transaction
+                        # we don't need to call __aenter__ of connection_transaction, it is not on the stack
             except BaseException as e:
                 self._connection_counter -= 1
                 raise e

--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -74,13 +74,20 @@ class ForceRollback:
         self.default = default
 
     def set(self, value: typing.Union[bool, None] = None) -> None:
-        if value is None:
-            value = self.default
         force_rollbacks = ACTIVE_FORCE_ROLLBACKS.get()
         if force_rollbacks is None:
+            # shortcut, we don't need to initialize anything for None (reset)
+            if value is None:
+                return
             force_rollbacks = weakref.WeakKeyDictionary()
-            ACTIVE_FORCE_ROLLBACKS.set(force_rollbacks)
-        force_rollbacks[self] = value
+        else:
+            force_rollbacks = force_rollbacks.copy()
+        if value is None:
+            force_rollbacks.pop(self, None)
+        else:
+            force_rollbacks[self] = value
+        # it is always a copy required to prevent sideeffects between the contexts
+        ACTIVE_FORCE_ROLLBACKS.set(force_rollbacks)
 
     def __bool__(self) -> bool:
         force_rollbacks = ACTIVE_FORCE_ROLLBACKS.get()

--- a/databasez/interfaces.py
+++ b/databasez/interfaces.py
@@ -32,6 +32,7 @@ class TransactionBackend(ABC):
         connection: ConnectionBackend,
         existing_transaction: typing.Optional[Transaction] = None,
     ):
+        # cannot be a weak ref otherwise connections get lost when retrieving them via transactions
         self.connection = connection
         self.raw_transaction = existing_transaction
 
@@ -235,14 +236,14 @@ class DatabaseBackend(ABC):
 
     @property
     def owner(self) -> typing.Optional[RootDatabase]:
-        result = self.__dict__.get("root")
+        result = self.__dict__.get("owner")
         if result is None:
             return None
         return typing.cast("RootDatabase", result())
 
     @owner.setter
     def owner(self, value: RootDatabase) -> None:
-        self.__dict__["root"] = weakref.ref(value)
+        self.__dict__["owner"] = weakref.ref(value)
 
     @abstractmethod
     async def connect(self, database_url: DatabaseURL, **options: typing.Any) -> None:

--- a/databasez/testclient.py
+++ b/databasez/testclient.py
@@ -235,7 +235,7 @@ class DatabaseTestClient(Database):
 
         await db_client.disconnect()
 
-    async def disconnect(self) -> None:
+    async def disconnect(self, force: bool = False) -> None:
         if self.drop:
             await self.drop_database(self.test_db_url)
-        await super().disconnect()
+        await super().disconnect(force)

--- a/docs/connections-and-transactions.md
+++ b/docs/connections-and-transactions.md
@@ -15,13 +15,14 @@ from databasez import Database
 
 **Parameters**
 
-* **url** - The `url` of the connection string.
+* **url** - The `url` of the connection string or a Database object to copy from.
 
   <sup>Default: `None`</sup>
 
-* **force_rollback** - A boolean flag indicating if it should force the rollback.
+* **force_rollback** - An optional boolean flag for force_rollback. Overwritable at runtime possible.
+                       Note: when None it copies the value from the provided Database object or sets it to False.
 
-  <sup>Default: `False`</sup>
+  <sup>Default: `None`</sup>
 
 * **config** - A python like dictionary as alternative to the `url` that contains the information
 to connect to the database.
@@ -33,6 +34,21 @@ to connect to the database.
 !!! Warning
     Be careful when setting up the `url` or `config`. You can use one or the other but not both
     at the same time.
+
+
+**Attributes***
+
+* **force_rollback**:
+    It evaluates its trueness value to the active value of force_rollback for this context.
+    You can delete it to reset it (`del database.force_rollback`) (it uses the descriptor magic).
+
+**Functions**
+
+* **__copy__** - Either usable directly or via copy from the copy module. A fresh Database object with the same options as the existing is created.
+                 Note: for creating a copy with overwritten initial force_rollback you can use: `Database(database_obj, force_rollback=False)`.
+                 Note: you have to connect it.
+
+* **force_rollback(force_rollback=True)**: - The magic attribute is also function returning a context-manager for temporary overwrites of force_rollback.
 
 
 ## Connecting and disconnecting

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## 0.9.0
+
+### Added
+
+- `force_rollback` is now a descriptor returning an extensive ForceRollback object.
+    - Setting True, False, None is now possible for overwriting the value/resetting to the initial value (None).
+    - Deleting it resets it to the initial value.
+    - Its trueness value evaluates to the current value, context-sensitive.
+    - It still can be used as a contextmanager for temporary overwrites.
+
+
+### Changed
+
+- `connect`/`disconnect` calls are now refcounted. Nesting is now supported.
+- ACTIVE_TRANSACTIONS dict is not replaced anymore when initialized.
+
+
 ## 0.8.5
 
 ### Added

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -10,6 +10,9 @@
     - Its trueness value evaluates to the current value, context-sensitive.
     - It still can be used as a contextmanager for temporary overwrites.
 
+### Fixed
+
+- Fixed refcount for global connections.
 
 ### Changed
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -204,6 +204,8 @@ async def test_transaction_context_cleanup_garbagecollector(database_url):
         assert len(open_transactions) == 1
         transaction = database.transaction()
         await transaction.start()
+        # is replaced after start() call
+        open_transactions = ACTIVE_TRANSACTIONS.get()
         assert len(open_transactions) == 2
 
         assert open_transactions.get(transaction) is transaction._transaction


### PR DESCRIPTION
Changes:
- make force_rollback smarter
- allow switching back from force_rollback
- allow nesting calls of Database
- document __copy__ and  force_rollback