### PR TITLE
more testclient hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-toml
@@ -13,7 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.5.1
+    rev: v0.5.7
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/databasez/__init__.py
+++ b/databasez/__init__.py
@@ -1,5 +1,5 @@
 from databasez.core import Database, DatabaseURL
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 __all__ = ["Database", "DatabaseURL"]

--- a/databasez/testclient.py
+++ b/databasez/testclient.py
@@ -27,6 +27,7 @@ class DatabaseTestClient(Database):
     This client simply creates a "test_" from the database provided in the
     connection.
     """
+
     # knob for changing the timeout of the setup and tear down of the db
     testclient_operation_timeout: float = 4
     # is used for copying Database and DatabaseTestClientand providing an early url

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,12 +6,14 @@
 
 - Add lazy_setup parameter for testclient.
 - `disconnect` and `connect` return if they performed the setup/cleanup.
+- Add backward compatible overwrites of defaults to the TestClient.
 
 ### Fixed
 
 - Restore eager setup behavior in testclient.
 - Fix drop_dabase with postgresql.
 - Fix setup/disconnect hangups.
+- Fix ancient docs deps.
 
 ### Removed
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Unreleased
+## 0.9.3
 
 ### Added
 

--- a/docs/test-client.md
+++ b/docs/test-client.md
@@ -71,12 +71,17 @@ The defaults of all parameters except the url can be changed by providing in a s
 
 `testclient_default_<parameter name>`
 
-There is also a knob for the operation timeout (setting up DB, dropping databases):
+There are also 2 knobs for the operation timeout (setting up DB, dropping databases):
 
 `testclient_operation_timeout`
 
 Default: `4`.
 
+and the limit
+
+`testclient_operation_timeout_init` for the non-lazy setup in init of the database.
+
+Default: `8`.
 
 ### How to use it
 

--- a/docs/test-client.md
+++ b/docs/test-client.md
@@ -40,33 +40,43 @@ from databasez.testclient import DatabaseTestClient
 
 ### Parameters
 
-* **url** - The database url for your database. This can be in a string format or in a
-`databasez.DatabaseURL`.
-
-    ```python
-    from databasez import DatabaseURL
-    ```
+* **url** - The database url for your database.
+            It supports the same types like normal Database objects and has a special handling for subclasses of DatabaseTestClient.
 
 * **force_rollback** - This will ensure that all database connections are run within a transaction
                        that rollbacks once the database is disconnected.
 
-    <sup>Default: `None`, copy default or False </sup>
+    <sup>Default: `None`, copy default or `testclient_default_force_rollback` (defaults to `False`) </sup>
 
 * **lazy_setup** - This sets up the db first up on connect not in init.
 
-    <sup>Default: `None`, True if copying a database or False otherwise</sup>
+    <sup>Default: `None`, True if copying a database or `testclient_default_lazy_setup` (defaults to `False`)</sup>
 
 * **use_existing** - Uses the existing `test_` database if previously created and not dropped.
 
-    <sup>Default: `False`</sup>
+    <sup>Default: `testclient_default_use_existing` (defaults to `False`)</sup>
 
-* **drop_database** - Ensures that after the tests, the database is dropped.
+* **drop_database** - Ensures that after the tests, the database is dropped. The corresponding attribute is `drop`.
+                      When the setup fails, it is automatically set to `False`.
 
-    <sup>Default: `False`</sup>
+    <sup>Default: `testclient_default_drop_database` (defaults to `False`)</sup>
 
 * **test_prefix** - Allow a custom test prefix or leave empty to use the url instead without changes.
 
-    <sup>Default: `test_`</sup>
+    <sup>Default: `testclient_default_test_prefix` (defaults to `test_`)</sup>
+
+### Subclassing
+
+The defaults of all parameters except the url can be changed by providing in a subclass a different value for the attribute:
+
+`testclient_default_<parameter name>`
+
+There is also a knob for the operation timeout (setting up DB, dropping databases):
+
+`testclient_operation_timeout`
+
+Default: `4`.
+
 
 ### How to use it
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,8 +33,7 @@ repo_url: https://github.com/dymmond/databasez
 edit_uri: ""
 plugins:
     - search
-    - markdownextradata:
-          data: data
+    - macros
 
 nav:
     - Databasez: "index.md"
@@ -64,8 +63,8 @@ markdown_extensions:
                 class: mermaid
                 format: !!python/name:pymdownx.superfences.fence_code_format ""
     - pymdownx.emoji:
-          emoji_index: !!python/name:materialx.emoji.twemoji
-          emoji_generator: !!python/name:materialx.emoji.to_svg
+          emoji_index: !!python/name:material.extensions.emoji.twemoji
+          emoji_generator: !!python/name:material.extensions.emoji.to_svg
     - pymdownx.tabbed:
           alternate_style: true
     - md_in_html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,10 +167,10 @@ clean_pycache = "find . -type d -name \"*__pycache__*\" -delete"
 dependencies = [
     "mkautodoc>=0.2.0,<0.3.0",
     "mkdocs>=1.4.2,<2.0.0",
-    "mkdocs-material==9.1.5",
+    "mkdocs-material>=9.4.4,<10.0.0",
     "mdx-include>=1.4.1,<2.0.0",
-    "mkdocs-markdownextradata-plugin>=0.1.7,<0.3.0",
-    "mkdocstrings>=0.19.0,<0.21.0",
+    "mkdocs-macros-plugin>=1.0.0,<2.0.0",
+    "mkdocstrings>=0.19.0,<0.26.0",
     "pyyaml>=5.3.1,<7.0.0",
 ]
 [tool.hatch.envs.docs.scripts]

--- a/tests/test_database_testclient.py
+++ b/tests/test_database_testclient.py
@@ -83,7 +83,6 @@ async def test_client_drop_existing(database_url):
         assert not await database2.database_exists(database.test_db_url)
 
 
-
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @pytest.mark.asyncio
 async def test_client_overwrite_defaults(database_url):
@@ -99,7 +98,6 @@ async def test_client_overwrite_defaults(database_url):
     # lazy setup
     assert database._setup_executed_init is False
     assert not await database.database_exists(database.test_db_url)
-
 
 
 @pytest.mark.parametrize("database_url", DATABASE_URLS)

--- a/tests/test_database_testclient.py
+++ b/tests/test_database_testclient.py
@@ -14,6 +14,10 @@ if not any((x.endswith(" for SQL Server") for x in pyodbc.drivers())):
     DATABASE_URLS = list(filter(lambda x: "mssql" not in x, DATABASE_URLS))
 
 
+class LazyTestClient(DatabaseTestClient):
+    testclient_default_lazy_setup: bool = True
+
+
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @pytest.mark.asyncio
 async def test_non_existing_normal(database_url):
@@ -77,3 +81,31 @@ async def test_client_drop_existing(database_url):
             await conn.fetch_all("select * from FOOBAR")
     if database2.drop:
         assert not await database2.database_exists(database.test_db_url)
+
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@pytest.mark.asyncio
+async def test_client_overwrite_defaults(database_url):
+    class DummyTestClient(LazyTestClient):
+        testclient_default_use_existing = True
+        testclient_default_drop_database = True
+        testclient_default_test_prefix = "foobar123"
+
+    database = DummyTestClient(database_url)
+    assert "foobar123" in database.test_db_url
+    assert database.use_existing is True
+    assert database.drop is True
+    # lazy setup
+    assert database._setup_executed_init is False
+    assert not await database.database_exists(database.test_db_url)
+
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@pytest.mark.parametrize("source_db_class", [Database, LazyTestClient])
+def test_client_copy(source_db_class, database_url):
+    ref_db = Database(database_url)
+    source_db = source_db_class(database_url, force_rollback=True)
+    copied = DatabaseTestClient(source_db, lazy_setup=True)
+    assert copied.url.database == f"test_{ref_db.url.database}"


### PR DESCRIPTION
Another round of updates:

- Expose knobs to configure the defaults of databasez Testclient. It is thought for edgy's or saffier testclient to provide a backward compatible interface also for some tricky parameters.
- Update docs setup.
- Document knobs in subclassing.