### PR TITLE
Fix connection after iterate

### DIFF
--- a/databasez/sqlalchemy.py
+++ b/databasez/sqlalchemy.py
@@ -139,13 +139,41 @@ class SQLAlchemyConnection(ConnectionBackend):
                 return
 
         await connection.execution_options(yield_per=batch_size)
-        async with connection.stream(  # type: ignore
-            query
-        ) as result:
-            async for batch in result.partitions():
-                yield batch
-        # undo the connection change
-        await connection.execution_options(yield_per=0)
+        try:
+            async with connection.stream(  # type: ignore
+                query
+            ) as result:
+                async for batch in result.partitions():
+                    yield batch
+        finally:
+            # undo the connection change
+            await connection.execution_options(yield_per=0)
+
+    async def iterate(
+        self, query: ClauseElement, batch_size: typing.Optional[int] = None
+    ) -> typing.AsyncGenerator[typing.Any, None]:
+        connection = self.async_connection
+        assert connection is not None, "Connection is not acquired"
+        database = self.database
+        assert database
+        if batch_size is None:
+            batch_size = database.default_batch_size
+
+        if not connection.dialect.supports_server_side_cursors:
+            with await self.execute_raw(query) as result:
+                for row in result.fetchall():
+                    yield row
+                return
+        await connection.execution_options(yield_per=batch_size)
+        try:
+            async with connection.stream(  # type: ignore
+                query
+            ) as result:
+                async for row in result:
+                    yield row
+        finally:
+            # undo the connection change
+            await connection.execution_options(yield_per=0)
 
     async def execute_raw(self, stmt: typing.Any, value: typing.Any = None) -> typing.Any:
         connection = self.async_connection

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Unreleased
+
+### Changed
+
+- Implement iterate in sqlalchemy base class (before it was a forward to batched_iterate).
+
+### Fixed
+
+- iterate and batched_iterate misconfigure connection.
+
 ## 0.9.3
 
 ### Added

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -162,6 +162,11 @@ async def test_queries(database_url):
         assert batched_iterate_results[1][0].text == "example3"
         assert batched_iterate_results[1][0].completed is True
 
+        # execute() after iterate
+        query = notes.insert()
+        values = {"text": "after_iterate", "completed": True}
+        defaults = await database.execute(query, values)
+
 
 @pytest.mark.asyncio
 async def test_queries_raw(database_url):

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -162,11 +162,6 @@ async def test_queries(database_url):
         assert batched_iterate_results[1][0].text == "example3"
         assert batched_iterate_results[1][0].completed is True
 
-        # execute() after iterate
-        query = notes.insert()
-        values = {"text": "after_iterate", "completed": True}
-        defaults = await database.execute(query, values)
-
 
 @pytest.mark.asyncio
 async def test_queries_raw(database_url):
@@ -245,6 +240,55 @@ async def test_ddl_queries(database_url):
             # CreateTable()
             query = sqlalchemy.schema.CreateTable(notes)
             await database.execute(query)
+
+
+@pytest.mark.asyncio
+async def test_connection_after_iterate(database_url):
+    """
+    Test that the connection is correctly resetted.
+    """
+
+    async with Database(database_url, force_rollback=True) as database:
+        # execute() before iterate
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        defaults = await database.execute(query, values)
+        assert defaults.id == 1
+        query = "SELECT * FROM notes"
+        results = []
+        async for result in database.iterate(query=query, chunk_size=2):
+            results.append(result)
+        assert len(results) == 1
+
+        # execute() after iterate
+        query = notes.insert()
+        values = {"text": "after_iterate", "completed": True}
+        defaults = await database.execute(query, values)
+
+
+@pytest.mark.asyncio
+async def test_connection_after_batched_iterate(database_url):
+    """
+    Test that the connection is correctly resetted.
+    """
+
+    async with Database(database_url, force_rollback=True) as database:
+        # execute() before batched_iterate
+        query = notes.insert()
+        values = {"text": "example1", "completed": True}
+        defaults = await database.execute(query, values)
+        assert defaults.id == 1
+        query = "SELECT * FROM notes"
+        results = []
+        async for result in database.batched_iterate(query=query, batch_size=2):
+            results.append(result)
+        assert len(results) == 1
+        assert len(results[0]) == 1
+
+        # execute() after batched_iterate
+        query = notes.insert()
+        values = {"text": "after_iterate", "completed": True}
+        defaults = await database.execute(query, values)
 
 
 @pytest.mark.parametrize("exception", [Exception, asyncio.CancelledError])


### PR DESCRIPTION
Currently batched_iterate and iterate doesn't reset the options which causes problems with inserts, ...

This PR fixes this and add test cases.

Plus it does implement iterate in the sqlalchemy reference class.