### PR TITLE
Fix: testclient can break with force_rollback on (especially drop_all)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ htmlcov/
 venv/
 .idea/
 testsuite.sqlite3
+test_testsuite.sqlite3

--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -232,7 +232,7 @@ class Database:
         return False
 
     async def connect_hook(self) -> None:
-        """Refcount protected connect hook. Executed after engine and global connection setup."""
+        """Refcount protected connect hook. Executed after engine and before global connection setup."""
 
     async def connect(self) -> bool:
         """
@@ -247,9 +247,9 @@ class Database:
         self.is_connected = True
 
         assert self._global_connection is None
+        await self.connect_hook()
 
         self._global_connection = Connection(self, self.backend, force_rollback=True)
-        await self.connect_hook()
         return True
 
     async def disconnect_hook(self) -> None:

--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -232,7 +232,7 @@ class Database:
         return False
 
     async def connect_hook(self) -> None:
-        """Refcount protected connect hook. Executed after engine and before global connection setup."""
+        """Refcount protected connect hook. Executed begore engine and global connection setup."""
 
     async def connect(self) -> bool:
         """
@@ -257,7 +257,7 @@ class Database:
         return True
 
     async def disconnect_hook(self) -> None:
-        """Refcount protected disconnect hook. Executed after connection cleanup but before engine disconnect."""
+        """Refcount protected disconnect hook. Executed after connection, engine cleanup."""
 
     async def disconnect(self, force: bool = False) -> bool:
         """

--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -232,7 +232,7 @@ class Database:
         return False
 
     async def connect_hook(self) -> None:
-        """Refcount protected connect hook"""
+        """Refcount protected connect hook. Executed after engine and global connection setup."""
 
     async def connect(self) -> bool:
         """
@@ -253,7 +253,7 @@ class Database:
         return True
 
     async def disconnect_hook(self) -> None:
-        """Refcount protected disconnect hook"""
+        """Refcount protected disconnect hook. Executed after connection cleanup but before engine disconnect."""
 
     async def disconnect(self, force: bool = False) -> bool:
         """
@@ -268,13 +268,13 @@ class Database:
             else:
                 return False
 
-        assert self._global_connection is not None
         try:
-            await self.disconnect_hook()
-        finally:
+            assert self._global_connection is not None
             await self._global_connection.__aexit__()
             self._global_connection = None
             self._connection = None
+            await self.disconnect_hook()
+        finally:
             try:
                 await self.backend.disconnect()
                 logger.info(

--- a/databasez/testclient.py
+++ b/databasez/testclient.py
@@ -187,6 +187,7 @@ class DatabaseTestClient(Database):
         dialect_name = url.sqla_url.get_dialect(True).name
         dialect_driver = url.sqla_url.get_dialect(True).driver
 
+        # we don't want to connect to a not existing db
         if dialect_name == "postgresql":
             url = url.replace(database="postgres")
         elif dialect_name == "mssql":
@@ -223,6 +224,7 @@ class DatabaseTestClient(Database):
 
             elif dialect_name == "sqlite" and database != ":memory:":
                 if database:
+                    # create a sqlite file
                     async with db_client.engine.begin() as conn:  # type: ignore
                         await conn.execute(sa.text("CREATE TABLE DB(id int)"))
                         await conn.execute(sa.text("DROP TABLE DB"))

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+
+## 0.9.5
+
+### Fixed
+
+- `disconnect_hook` was called too early.
+
 ## 0.9.4
 
 ### Changed

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - `disconnect_hook` was called too early.
+- `connect_hook` was called too late.
 
 ## 0.9.4
 

--- a/tests/test_database_testclient.py
+++ b/tests/test_database_testclient.py
@@ -145,7 +145,18 @@ async def test_client_fails_on_disconnect_hook(database_url):
     database = FailingDisconnectTestClient(database_url)
     with pytest.raises(HookException):
         async with database:
-            pass
+            assert database.is_connected == True
     assert database.is_connected == False
     # return True, would connect again
     assert await database.inc_refcount()
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@pytest.mark.asyncio
+async def test_client_fails_during_op(database_url):
+    # mssql cannot drop master db
+    database = LazyTestClient(database_url, use_existing=True)
+    with pytest.raises(HookException):
+        async with database:
+            raise HookException()
+    assert database.is_connected == False

--- a/tests/test_database_testclient.py
+++ b/tests/test_database_testclient.py
@@ -18,6 +18,7 @@ class LazyTestClient(DatabaseTestClient):
     testclient_default_lazy_setup: bool = True
 
 
+# BaseExceptions are harder to catch so test against them
 class HookException(BaseException):
     pass
 

--- a/tests/test_database_testclient.py
+++ b/tests/test_database_testclient.py
@@ -18,6 +18,23 @@ class LazyTestClient(DatabaseTestClient):
     testclient_default_lazy_setup: bool = True
 
 
+class HookException(BaseException):
+    pass
+
+
+class FailingConnectTestClient(LazyTestClient):
+    async def connect_hook(self) -> None:
+        raise HookException()
+
+
+class FailingDisconnectTestClient(LazyTestClient):
+    async def connect_hook(self) -> None:
+        pass
+
+    async def disconnect_hook(self) -> None:
+        raise HookException()
+
+
 @pytest.mark.parametrize("database_url", DATABASE_URLS)
 @pytest.mark.asyncio
 async def test_non_existing_normal(database_url):
@@ -107,3 +124,27 @@ def test_client_copy(source_db_class, database_url):
     source_db = source_db_class(database_url, force_rollback=True)
     copied = DatabaseTestClient(source_db, lazy_setup=True)
     assert copied.url.database == f"test_{ref_db.url.database}"
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@pytest.mark.asyncio
+async def test_client_fails_on_connect_hook(database_url):
+    database = FailingConnectTestClient(database_url)
+    with pytest.raises(HookException):
+        async with database:
+            pass
+    assert database.is_connected == False
+    # return True, would connect again
+    assert await database.inc_refcount()
+
+
+@pytest.mark.parametrize("database_url", DATABASE_URLS)
+@pytest.mark.asyncio
+async def test_client_fails_on_disconnect_hook(database_url):
+    database = FailingDisconnectTestClient(database_url)
+    with pytest.raises(HookException):
+        async with database:
+            pass
+    assert database.is_connected == False
+    # return True, would connect again
+    assert await database.inc_refcount()


### PR DESCRIPTION
currently testclient can break with force_rollback on. Fix this by reordering the disconnect hook after the connection cleanup and the connect_hook before the global connection setup.

Sideeffect: testclient tests speed up.

Found during tests with edgy.