### PR TITLE
multithread safety

### DIFF
--- a/databasez/__init__.py
+++ b/databasez/__init__.py
@@ -1,5 +1,5 @@
 from databasez.core import Database, DatabaseURL
 
-__version__ = "0.9.5"
+__version__ = "0.9.6"
 
 __all__ = ["Database", "DatabaseURL"]

--- a/databasez/core/connection.py
+++ b/databasez/core/connection.py
@@ -8,6 +8,7 @@ from types import TracebackType
 from sqlalchemy import text
 
 from databasez import interfaces
+from databasez.utils import thread_protector
 
 from .transaction import Transaction
 
@@ -37,6 +38,7 @@ class Connection:
         self._force_rollback = force_rollback
         self.connection_transaction: typing.Optional[Transaction] = None
 
+    @thread_protector(True)
     async def __aenter__(self) -> Connection:
         async with self._connection_lock:
             self._connection_counter += 1
@@ -83,6 +85,11 @@ class Connection:
                     await self._connection.release()
                     self._database._connection = None
 
+    @property
+    def _loop(self) -> typing.Any:
+        return self._database._loop
+
+    @thread_protector(True)
     async def fetch_all(
         self,
         query: typing.Union[ClauseElement, str],
@@ -92,6 +99,7 @@ class Connection:
         async with self._query_lock:
             return await self._connection.fetch_all(built_query)
 
+    @thread_protector(True)
     async def fetch_one(
         self,
         query: typing.Union[ClauseElement, str],
@@ -102,6 +110,7 @@ class Connection:
         async with self._query_lock:
             return await self._connection.fetch_one(built_query, pos=pos)
 
+    @thread_protector(True)
     async def fetch_val(
         self,
         query: typing.Union[ClauseElement, str],
@@ -113,6 +122,7 @@ class Connection:
         async with self._query_lock:
             return await self._connection.fetch_val(built_query, column, pos=pos)
 
+    @thread_protector(True)
     async def execute(
         self,
         query: typing.Union[ClauseElement, str],
@@ -126,6 +136,7 @@ class Connection:
             async with self._query_lock:
                 return await self._connection.execute(query, values)
 
+    @thread_protector(True)
     async def execute_many(
         self, query: typing.Union[ClauseElement, str], values: typing.Any = None
     ) -> typing.Union[typing.Sequence[interfaces.Record], int]:
@@ -137,6 +148,7 @@ class Connection:
             async with self._query_lock:
                 return await self._connection.execute_many(query, values)
 
+    @thread_protector(True)
     async def iterate(
         self,
         query: typing.Union[ClauseElement, str],
@@ -148,6 +160,7 @@ class Connection:
             async for record in self._connection.iterate(built_query, batch_size):
                 yield record
 
+    @thread_protector(True)
     async def batched_iterate(
         self,
         query: typing.Union[ClauseElement, str],
@@ -159,6 +172,7 @@ class Connection:
             async for records in self._connection.batched_iterate(built_query, batch_size):
                 yield records
 
+    @thread_protector(True)
     async def run_sync(
         self,
         fn: typing.Callable[..., typing.Any],
@@ -168,20 +182,25 @@ class Connection:
         async with self._query_lock:
             return await self._connection.run_sync(fn, *args, **kwargs)
 
+    @thread_protector(True)
     async def create_all(self, meta: MetaData, **kwargs: typing.Any) -> None:
         await self.run_sync(meta.create_all, **kwargs)
 
+    @thread_protector(True)
     async def drop_all(self, meta: MetaData, **kwargs: typing.Any) -> None:
         await self.run_sync(meta.drop_all, **kwargs)
 
+    @thread_protector(True)
     def transaction(self, *, force_rollback: bool = False, **kwargs: typing.Any) -> "Transaction":
         return Transaction(weakref.ref(self), force_rollback, **kwargs)
 
     @property
+    @thread_protector(True)
     def async_connection(self) -> typing.Any:
         """The first layer (sqlalchemy)."""
         return self._connection.async_connection
 
+    @thread_protector(True)
     async def get_raw_connection(self) -> typing.Any:
         """The real raw connection (driver)."""
         return await self.async_connection.get_raw_connection()

--- a/databasez/utils.py
+++ b/databasez/utils.py
@@ -161,6 +161,7 @@ def multiloop_protector(
     fail_with_different_loop: bool, wrap_context_manager: bool = False
 ) -> typing.Callable[[MultiloopProtectorCallable], MultiloopProtectorCallable]:
     """For multiple threads or other reasons why the loop changes"""
+
     # True works with all methods False only for methods of Database
     # needs _loop attribute to check against
     def _decorator(fn: MultiloopProtectorCallable) -> MultiloopProtectorCallable:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-- Databasez is now threadsafe.
+- Databasez is now threadsafe (and multiloop safe).
 
 
 ## 0.9.5

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,13 @@
 # Release Notes
 
 
+## 0.9.6
+
+### Fixed
+
+- Databasez is now threadsafe.
+
+
 ## 0.9.5
 
 ### Changed


### PR DESCRIPTION
Make multithreading safe (better said: multiloop).

Useful if you need multiple loops.

Given the importance I would request a fast release.