### PR TITLE
improve multiloop callforwarding

### DIFF
--- a/databasez/__init__.py
+++ b/databasez/__init__.py
@@ -1,5 +1,5 @@
 from databasez.core import Database, DatabaseURL
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"
 
 __all__ = ["Database", "DatabaseURL"]

--- a/databasez/core/connection.py
+++ b/databasez/core/connection.py
@@ -38,7 +38,7 @@ class Connection:
         self._force_rollback = force_rollback
         self.connection_transaction: typing.Optional[Transaction] = None
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def __aenter__(self) -> Connection:
         async with self._connection_lock:
             self._connection_counter += 1
@@ -65,6 +65,7 @@ class Connection:
                 raise e
         return self
 
+    @multiloop_protector(False)
     async def __aexit__(
         self,
         exc_type: typing.Optional[typing.Type[BaseException]] = None,
@@ -89,7 +90,7 @@ class Connection:
     def _loop(self) -> typing.Any:
         return self._database._loop
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def fetch_all(
         self,
         query: typing.Union[ClauseElement, str],
@@ -99,7 +100,7 @@ class Connection:
         async with self._query_lock:
             return await self._connection.fetch_all(built_query)
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def fetch_one(
         self,
         query: typing.Union[ClauseElement, str],
@@ -110,7 +111,7 @@ class Connection:
         async with self._query_lock:
             return await self._connection.fetch_one(built_query, pos=pos)
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def fetch_val(
         self,
         query: typing.Union[ClauseElement, str],
@@ -122,7 +123,7 @@ class Connection:
         async with self._query_lock:
             return await self._connection.fetch_val(built_query, column, pos=pos)
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def execute(
         self,
         query: typing.Union[ClauseElement, str],
@@ -136,7 +137,7 @@ class Connection:
             async with self._query_lock:
                 return await self._connection.execute(query, values)
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def execute_many(
         self, query: typing.Union[ClauseElement, str], values: typing.Any = None
     ) -> typing.Union[typing.Sequence[interfaces.Record], int]:
@@ -148,7 +149,7 @@ class Connection:
             async with self._query_lock:
                 return await self._connection.execute_many(query, values)
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def iterate(
         self,
         query: typing.Union[ClauseElement, str],
@@ -160,7 +161,7 @@ class Connection:
             async for record in self._connection.iterate(built_query, batch_size):
                 yield record
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def batched_iterate(
         self,
         query: typing.Union[ClauseElement, str],
@@ -172,7 +173,7 @@ class Connection:
             async for records in self._connection.batched_iterate(built_query, batch_size):
                 yield records
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def run_sync(
         self,
         fn: typing.Callable[..., typing.Any],
@@ -182,15 +183,15 @@ class Connection:
         async with self._query_lock:
             return await self._connection.run_sync(fn, *args, **kwargs)
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def create_all(self, meta: MetaData, **kwargs: typing.Any) -> None:
         await self.run_sync(meta.create_all, **kwargs)
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def drop_all(self, meta: MetaData, **kwargs: typing.Any) -> None:
         await self.run_sync(meta.drop_all, **kwargs)
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     def transaction(self, *, force_rollback: bool = False, **kwargs: typing.Any) -> "Transaction":
         return Transaction(weakref.ref(self), force_rollback, **kwargs)
 
@@ -200,7 +201,7 @@ class Connection:
         """The first layer (sqlalchemy)."""
         return self._connection.async_connection
 
-    @multiloop_protector(True)
+    @multiloop_protector(False)
     async def get_raw_connection(self) -> typing.Any:
         """The real raw connection (driver)."""
         return await self.async_connection.get_raw_connection()

--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -220,6 +220,14 @@ class Database:
         return self._connection
 
     async def inc_refcount(self) -> bool:
+        """
+        Internal method to bump the ref_count.
+
+        Return True if ref_count is 0, False otherwise.
+
+        Should not be used outside of tests. Use connect and hooks instead.
+        Not multithreading safe!
+        """
         async with self.ref_lock:
             self.ref_counter += 1
             # on the first call is count is 1 because of the former +1
@@ -228,6 +236,14 @@ class Database:
         return False
 
     async def decr_refcount(self) -> bool:
+        """
+        Internal method to decrease the ref_count.
+
+        Return True if ref_count drops to 0, False otherwise.
+
+        Should not be used outside of tests. Use disconnect and hooks instead.
+        Not multithreading safe!
+        """
         async with self.ref_lock:
             self.ref_counter -= 1
             # on the last call, the count is 0

--- a/databasez/overwrites/jdbc.py
+++ b/databasez/overwrites/jdbc.py
@@ -2,6 +2,8 @@ import os
 import typing
 from pathlib import Path
 
+# ensure jpype.dbapi2 is initialized. Prevent race condition.
+import jpype.dbapi2  # noqa
 from jpype import addClassPath, isJVMStarted, startJVM
 
 from databasez.sqlalchemy import SQLAlchemyDatabase, SQLAlchemyTransaction

--- a/databasez/utils.py
+++ b/databasez/utils.py
@@ -1,9 +1,9 @@
 import asyncio
 import inspect
 import typing
-from contextlib import asynccontextmanager
 from functools import partial, wraps
 from threading import Thread
+from types import TracebackType
 
 async_wrapper_slots = (
     "_async_wrapped",
@@ -140,25 +140,98 @@ class ThreadPassingExceptions(Thread):
 MultiloopProtectorCallable = typing.TypeVar("MultiloopProtectorCallable", bound=typing.Callable)
 
 
-async def _async_helper(
-    database: typing.Any, fn: MultiloopProtectorCallable, *args: typing.Any, **kwargs: typing.Any
-) -> typing.Any:
-    # copy
-    async with database.__class__(database) as new_database:
-        return await fn(new_database, *args, **kwargs)
+class AsyncHelperDatabase:
+    def __init__(
+        self,
+        database: typing.Any,
+        fn: typing.Callable,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        self.database = database.__copy__()
+        self.fn = partial(fn, self.database, *args, **kwargs)
+        self.ctm = None
+
+    async def call(self) -> typing.Any:
+        async with self.database:
+            return await self.fn()
+
+    def __await__(self) -> typing.Any:
+        return self.call().__await__()
+
+    async def __aenter__(self) -> typing.Any:
+        await self.database.__aenter__()
+        self.ctm = self.fn()
+        return await self.ctm.__aenter__()
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Optional[typing.Type[BaseException]] = None,
+        exc_value: typing.Optional[BaseException] = None,
+        traceback: typing.Optional[TracebackType] = None,
+    ) -> None:
+        assert self.ctm is not None
+        try:
+            await self.ctm.__aexit__(exc_type, exc_value, traceback)
+        finally:
+            await self.database.__aexit__()
 
 
-@asynccontextmanager
-async def _contextmanager_helper(
-    database: typing.Any, fn: MultiloopProtectorCallable, *args: typing.Any, **kwargs: typing.Any
-) -> typing.Any:
-    async with database.__copy__() as new_database:
-        async with fn(new_database, *args, **kwargs) as result:
-            yield result
+class AsyncHelperConnection:
+    def __init__(
+        self,
+        connection: typing.Any,
+        fn: typing.Callable,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> None:
+        self.connection = connection
+        self.fn = partial(fn, self.connection, *args, **kwargs)
+        self.ctm = None
+
+    async def call(self) -> typing.Any:
+        async with self.connection:
+            result = self.fn()
+            if inspect.isawaitable(result):
+                result = await result
+            return result
+
+    async def acall(self) -> typing.Any:
+        return asyncio.run_coroutine_threadsafe(self.call(), self.connection._loop).result()
+
+    def __await__(self) -> typing.Any:
+        return self.acall().__await__()
+
+    async def enter_intern(self) -> typing.Any:
+        await self.connection.__aenter__()
+        self.ctm = await self.call()
+        return await self.ctm.__aenter__()
+
+    async def exit_intern(self) -> typing.Any:
+        assert self.ctm is not None
+        try:
+            await self.ctm.__aexit__()
+        finally:
+            self.ctm = None
+            await self.connection.__aexit__()
+
+    async def __aenter__(self) -> typing.Any:
+        return asyncio.run_coroutine_threadsafe(
+            self.enter_intern(), self.connection._loop
+        ).result()
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Optional[typing.Type[BaseException]] = None,
+        exc_value: typing.Optional[BaseException] = None,
+        traceback: typing.Optional[TracebackType] = None,
+    ) -> None:
+        assert self.ctm is not None
+        asyncio.run_coroutine_threadsafe(self.exit_intern(), self.connection._loop).result()
 
 
 def multiloop_protector(
-    fail_with_different_loop: bool, wrap_context_manager: bool = False, inject_parent: bool = False
+    fail_with_different_loop: bool, inject_parent: bool = False
 ) -> typing.Callable[[MultiloopProtectorCallable], MultiloopProtectorCallable]:
     """For multiple threads or other reasons why the loop changes"""
 
@@ -184,9 +257,12 @@ def multiloop_protector(
                 else:
                     if fail_with_different_loop:
                         raise RuntimeError("Different loop used")
-                    if wrap_context_manager:
-                        return _contextmanager_helper(self, fn, *args, **kwargs)
-                    return _async_helper(self, fn, *args, **kwargs)
+                    helper = (
+                        AsyncHelperDatabase
+                        if hasattr(self, "_databases_map")
+                        else AsyncHelperConnection
+                    )
+                    return helper(self, fn, *args, **kwargs)
             return fn(self, *args, **kwargs)
 
         return typing.cast(MultiloopProtectorCallable, wrapper)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,11 +5,12 @@
 
 ### Added
 
-- It is now possible to use connect(), disconnect() instead of a async contextmanager in multithread scenarios.
+- It is now possible to use connect(), disconnect() instead of a async contextmanager in multi-loop calls (multithreading).
 
 ### Fixed
 
 - Database calls are forwarded to subdatabase when possible. This unbreaks using not the returned database object.
+- `force_rollback` works also in multi-loop call (multithreading).
 
 ## 0.9.6
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,16 @@
 # Release Notes
 
 
+## 0.9.7
+
+### Added
+
+- It is now possible to use connect(), disconnect() instead of a async contextmanager in multithread scenarios.
+
+### Fixed
+
+- Database calls are forwarded to subdatabase when possible. This unbreaks using not the returned database object.
+
 ## 0.9.6
 
 ### Fixed

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -889,14 +889,20 @@ async def test_multi_thread(database_url, force_rollback):
         await asyncio.gather(db_lookup(False), wrap_in_thread(), wrap_in_thread())
 
 
+@pytest.mark.parametrize("force_rollback", [True, False])
 @pytest.mark.asyncio
-async def test_multi_thread_db_contextmanager(database_url):
-    async with Database(database_url, force_rollback=False) as database:
+async def test_multi_thread_db_contextmanager(database_url, force_rollback):
+    async with Database(database_url, force_rollback=force_rollback) as database:
+        query = notes.insert().values(text="examplecontext", completed=True)
+        await database.execute(query)
 
         async def db_connect(depth=3):
             # many parallel and nested threads
             async with database as new_database:
-                await new_database.fetch_one("SELECT 1")
+                query = notes.select()
+                result = await database.fetch_one(query)
+                assert result.text == "examplecontext"
+                assert result.completed is True
                 # test delegate to sub database
                 assert database.engine is new_database.engine
                 # also this shouldn't fail because redirected
@@ -913,6 +919,11 @@ async def test_multi_thread_db_contextmanager(database_url):
 
         await to_thread(asyncio.run, db_connect())
     assert database.ref_counter == 0
+    if force_rollback:
+        async with database:
+            query = notes.select()
+            result = await database.fetch_one(query)
+            assert result is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Changes:
- improve call forwarding
- allow now using connect instead of the async contextmanager
- unbreak idioms in multithread scenarios which does not use the returned Database of async contextmanager but the parent database
- fix force_rollback