### PR TITLE
raise errors when improper use

### DIFF
--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -449,6 +449,8 @@ class Database:
 
     @multiloop_protector(False)
     def connection(self) -> Connection:
+        if not self.is_connected:
+            raise RuntimeError("Database is not connected")
         if self.force_rollback:
             return typing.cast(Connection, self._global_connection)
 

--- a/databasez/sqlalchemy.py
+++ b/databasez/sqlalchemy.py
@@ -295,5 +295,6 @@ class SQLAlchemyDatabase(DatabaseBackend):
 
     async def disconnect(self) -> None:
         engine = self.engine
+        self.engine = None
         assert engine is not None, "database is not initialized"
         await engine.dispose()


### PR DESCRIPTION
Changes:
- set the engine to None after disconnect. This prevents an incorrect reuse.
- raise RuntimeError when db is not connected but connections are created.