### PR TITLE
update ruff, cleanup database methods on testclient

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -93,4 +93,5 @@ jobs:
         run: "hatch run test:check_types"
       - name: "Run tests"
         if: steps.filters.outputs.src == 'true' || steps.filters.outputs.workflows == 'true' || github.event.schedule != ''
-        run: env TEST_NO_RISK_SEGFAULTS=true hatch test
+        # test with xdist as still segfaults occur
+        run: env TEST_NO_RISK_SEGFAULTS=true hatch test -- -n 1 --dist no

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.6.4
+    rev: v0.10.0
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/databasez/__init__.py
+++ b/databasez/__init__.py
@@ -1,5 +1,5 @@
 from databasez.core import Database, DatabaseURL
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"
 
 __all__ = ["Database", "DatabaseURL"]

--- a/databasez/core/database.py
+++ b/databasez/core/database.py
@@ -328,7 +328,7 @@ class Database:
         return False
 
     async def connect_hook(self) -> None:
-        """Refcount protected connect hook. Executed begore engine and global connection setup."""
+        """Refcount protected connect hook. Executed before engine and global connection setup."""
 
     async def connect(self) -> bool:
         """
@@ -343,9 +343,9 @@ class Database:
                 raise RuntimeError("Subdatabases and polling are disabled")
             # copy when not in map
             if loop not in self._databases_map:
-                assert (
-                    self._global_connection is not None
-                ), "global connection should have been set"
+                assert self._global_connection is not None, (
+                    "global connection should have been set"
+                )
                 # correctly initialize force_rollback with parent value
                 database = self.__class__(
                     self, force_rollback=bool(self.force_rollback), full_isolation=False
@@ -405,7 +405,9 @@ class Database:
             assert not self._databases_map, "sub databases still active, force terminate them"
             for sub_database in self._databases_map.values():
                 await arun_coroutine_threadsafe(
-                    sub_database.disconnect(True), sub_database._loop, self.poll_interval
+                    sub_database.disconnect(True),
+                    sub_database._loop,
+                    self.poll_interval,
                 )
             self._databases_map = {}
         assert not self._databases_map, "sub databases still active"
@@ -556,7 +558,9 @@ class Database:
     @multiloop_protector(False)
     def _non_global_connection(
         self,
-        timeout: float | None = None,  # stub for type checker, multiloop_protector handles timeout
+        timeout: (
+            float | None
+        ) = None,  # stub for type checker, multiloop_protector handles timeout
     ) -> Connection:
         if self._connection is None:
             _connection = self._connection = Connection(self)
@@ -624,7 +628,8 @@ class Database:
                 module = importlib.import_module(imp_path)
             except ImportError as exc:
                 logging.debug(
-                    f'Import of "{imp_path}" failed. This is not an error.', exc_info=exc
+                    f'Import of "{imp_path}" failed. This is not an error.',
+                    exc_info=exc,
                 )
                 if "+" in scheme:
                     imp_path = f"{overwrite_path}.{scheme.split('+', 1)[0]}"
@@ -632,7 +637,8 @@ class Database:
                         module = importlib.import_module(imp_path)
                     except ImportError as exc:
                         logging.debug(
-                            f'Import of "{imp_path}" failed. This is not an error.', exc_info=exc
+                            f'Import of "{imp_path}" failed. This is not an error.',
+                            exc_info=exc,
                         )
             if module is not None:
                 break

--- a/databasez/dialects/dbapi2.py
+++ b/databasez/dialects/dbapi2.py
@@ -14,7 +14,6 @@ from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 from sqlalchemy.sql import text
 from sqlalchemy.util.concurrency import await_only
-from sqlalchemy_utils.functions.orm import quote
 
 from databasez.utils import AsyncWrapper
 
@@ -118,7 +117,8 @@ class DBAPI2_dialect(DefaultDialect):
         schema: str | None = None,
         **kw: Any,
     ) -> bool:
-        stmt = text(f"select * from '{quote(connection, table_name)}' LIMIT 1")
+        quoted = self.identifier_preparer.quote(table_name)
+        stmt = text(f"select 1 from '{quoted}' LIMIT 1")
         try:
             connection.execute(stmt)
             return True

--- a/databasez/dialects/jdbc.py
+++ b/databasez/dialects/jdbc.py
@@ -27,7 +27,6 @@ from sqlalchemy.engine.interfaces import (
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 from sqlalchemy.sql import sqltypes, text
 from sqlalchemy.util.concurrency import await_only
-from sqlalchemy_utils.functions.orm import quote
 
 from databasez.utils import AsyncWrapper
 
@@ -113,7 +112,8 @@ class JDBC_dialect(DefaultDialect):
         schema: str | None = None,
         **kw: Any,
     ) -> bool:
-        stmt = text(f"select * from '{quote(connection, table_name)}' LIMIT 1")
+        quoted = self.identifier_preparer.quote(table_name)
+        stmt = text(f"SELECT 1 from '{quoted}' LIMIT 1")
         try:
             connection.execute(stmt)
             return True

--- a/databasez/sqlalchemy.py
+++ b/databasez/sqlalchemy.py
@@ -57,9 +57,9 @@ class SQLAlchemyTransaction(TransactionBackend):
             self.old_transaction_level = ""
         if extra_options:
             await connection.execution_options(**extra_options)
-        assert (
-            await connection.get_isolation_level() != "AUTOCOMMIT"
-        ), "transactions doesn't work with AUTOCOMMIT. Please specify another transaction level."
+        assert await connection.get_isolation_level() != "AUTOCOMMIT", (
+            "transactions doesn't work with AUTOCOMMIT. Please specify another transaction level."
+        )
         if in_transaction:
             self.raw_transaction = await connection.begin_nested()
         else:

--- a/databasez/testclient.py
+++ b/databasez/testclient.py
@@ -155,7 +155,7 @@ class DatabaseTestClient(Database):
             return False
 
         elif dialect_name == "mysql":
-            for db in (database, None):
+            for db in (database, None, "root"):
                 url = url.replace(database=db)
                 try:
                     async with Database(

--- a/databasez/utils.py
+++ b/databasez/utils.py
@@ -244,7 +244,7 @@ def get_dialect(async_conn_or_dialect: SQLAConnection | Dialect, /) -> Dialect:
         return async_conn_or_dialect
     if hasattr(async_conn_or_dialect, "bind"):
         async_conn_or_dialect = async_conn_or_dialect.bind
-    return cast("Dialect", async_conn_or_dialect.dialect)
+    return cast("SQLAConnection", async_conn_or_dialect).dialect
 
 
 def get_quoter(async_conn_or_dialect: SQLAConnection | Dialect, /) -> Callable[[str], str]:

--- a/databasez/utils.py
+++ b/databasez/utils.py
@@ -170,9 +170,11 @@ class ThreadPassingExceptions(Thread):
             self._exc_raised = exc
 
     def join(self, timeout: float | int | None = None) -> None:
-        super().join(timeout=timeout)
-        if self._exc_raised:
-            raise self._exc_raised
+        try:
+            super().join(timeout=timeout)
+        finally:
+            if self._exc_raised is not None:
+                raise self._exc_raised
 
 
 MultiloopProtectorCallable = TypeVar("MultiloopProtectorCallable", bound=Callable)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 0.11.2
+
+### Fixed
+
+- Ruff calls were using different rulesets.
+- Cleaned up `database_exist`, `drop_database`, `create_database` methods of DatabaseTestClient.
+- Remove dependency on sqlalchemy_utils.
+- Provide get_quoter for retrieving a quote method.
+
 ## 0.11.1
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ extra-dependencies = [
     "pytest-timeouts",
     "pytest-rerunfailures",
     "pytest-asyncio",
+    "pytest-xdist",
     "anyio",
     "uvloop"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["sqlalchemy[asyncio]>=2.0.25,<2.1", "orjson", "sqlalchemy_utils>=0.40.0"]
+dependencies = ["sqlalchemy[asyncio]>=2.0.25,<2.1", "orjson"]
 keywords = [
     "mysql",
     "postgres",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,8 @@ include = ["/databasez"]
 [tool.hatch.envs.default]
 features = ["all"]
 extra-dependencies = [
+    # for debugging
+    "sqlalchemy_utils",
     "ipdb>=0.13.13",
     "pre-commit>=2.17.0,<4.0.0",
 ]
@@ -179,10 +181,10 @@ serve = "mkdocs serve --dev-addr localhost:8000"
 
 
 [tool.hatch.envs.test]
+# type-checking
 features = ["all"]
 extra-dependencies = [
     "mypy>=1.1.0,<2.0.0",
-    "psycopg[binary]",
 ]
 
 [tool.hatch.envs.test.scripts]
@@ -198,6 +200,8 @@ dependencies = ["ruff==0.10.0"]
 features = ["all"]
 
 extra-dependencies = [
+    # for debugging
+    "sqlalchemy_utils",
     "ipdb>=0.13.13",
     "esmerald>=1.1.0",
     "mypy>=1.1.0,<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,11 @@ extra-dependencies = [
 [tool.hatch.envs.test.scripts]
 check_types = "mypy -p databasez"
 
+[tool.hatch.envs.hatch-static-analysis]
+# disables custom ruff rules, required to align with pre-commit
+config-path = "none"
+dependencies = ["ruff==0.10.0"]
+
 
 [tool.hatch.envs.hatch-test]
 features = ["all"]

--- a/tests/test_dbapi2.py
+++ b/tests/test_dbapi2.py
@@ -28,6 +28,20 @@ async def test_dbapi2_connect():
 
 
 @pytest.mark.asyncio
+async def test_dialect_quote():
+    async with Database("dbapi2://testsuite.sqlite3", dbapi_path="sqlite3") as database:
+        dialect = database.engine.dialect
+        await database.create_all(metadata)
+        try:
+            assert await database.run_sync(dialect.has_table, "notes")
+            assert not await database.run_sync(dialect.has_table, "no'\"%tes")
+            assert dialect.identifier_preparer.quote("ijfosisdfop") == "ijfosisdfop"
+            assert dialect.identifier_preparer.quote("ijfos'i'sdfop") != "ijfos'i'sdfop"
+        finally:
+            await database.drop_all(metadata)
+
+
+@pytest.mark.asyncio
 async def test_dbapi2_queries():
     """
     Test that the basic `execute()`, `execute_many()`, `fetch_all()``,

--- a/tests/test_newer_jdbc.py
+++ b/tests/test_newer_jdbc.py
@@ -46,6 +46,25 @@ async def test_jdbc_connect():
 
 
 @pytest.mark.asyncio
+async def test_dialect_quote():
+    async with (
+        Database(
+            "jdbc+sqlite://testsuite.sqlite3?classpath=tests/sqlite-jdbc-3.47.0.0.jar&jdbc_driver=org.sqlite.JDBC"
+        ) as database,
+        database.connection() as connection,
+    ):
+        dialect = database.engine.dialect
+        await connection.create_all(metadata)
+        try:
+            assert await connection.run_sync(dialect.has_table, "notes")
+            assert not await connection.run_sync(dialect.has_table, "no'\"%tes")
+            assert dialect.identifier_preparer.quote("ijfosisdfop") == "ijfosisdfop"
+            assert dialect.identifier_preparer.quote("ijfos'i'sdfop") != "ijfos'i'sdfop"
+        finally:
+            await database.drop_all(metadata)
+
+
+@pytest.mark.asyncio
 async def test_jdbc_queries():
     """
     Test that the basic `execute()`, `execute_many()`, `fetch_all()``,

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -65,7 +65,7 @@ async def test_iterate_outside_transaction_with_values(database_url):
         pytest.skip("MySQL does not support `FROM (VALUES ...)` (F641)")
 
     async with Database(database_url) as database:
-        if database_url.dialect == "mssql":
+        if database_url.dialect == "mssql":  # noqa: SIM108
             query = "SELECT * FROM (VALUES (1), (2), (3), (4), (5)) as X(t)"
         else:
             query = "SELECT * FROM (VALUES (1), (2), (3), (4), (5)) as t"
@@ -244,7 +244,10 @@ async def test_transaction_commit(database_url):
     Ensure that transaction commit is supported.
     """
 
-    async with Database(database_url) as database, database.transaction(force_rollback=True):
+    async with (
+        Database(database_url) as database,
+        database.transaction(force_rollback=True),
+    ):
         async with database.transaction():
             query = notes.insert().values(text="example1", completed=True)
             await database.execute(query)
@@ -363,7 +366,10 @@ async def test_transaction_rollback_low_level(database_url):
     Ensure that an explicit `await transaction.rollback()` is supported.
     """
 
-    async with Database(database_url) as database, database.transaction(force_rollback=True):
+    async with (
+        Database(database_url) as database,
+        database.transaction(force_rollback=True),
+    ):
         transaction = await database.transaction()
         try:
             query = notes.insert().values(text="example1", completed=True)


### PR DESCRIPTION
    
Changes:

- ruff is now version 0.10.0
- ruff versions of precommit and hatch fmt use the same rules
- apply ruff rules
- cleanup in DatabaseTestClient the database_exist method
- the database_exist method is now more lenient against missing
  permission errors or missing databases for all dbs
- cleanup database_create, drop to use the Connection of databasez
-remove dependency on sqlalchemy_utils (only for debug purposes)
- harden gh action against segfaults


