### PR TITLE
lock confusing logging behind knob

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-toml
@@ -13,7 +13,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.10.0
+    rev: v0.11.8
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/databasez/__init__.py
+++ b/databasez/__init__.py
@@ -1,5 +1,5 @@
 from databasez.core import Database, DatabaseURL
 
-__version__ = "0.11.2"
+__version__ = "0.11.3"
 
 __all__ = ["Database", "DatabaseURL"]

--- a/databasez/utils.py
+++ b/databasez/utils.py
@@ -11,6 +11,7 @@ from typing import Any, TypeVar, cast
 from sqlalchemy.engine import Connection as SQLAConnection
 from sqlalchemy.engine import Dialect
 
+DATABASEZ_OVERWRITE_LOGGING: bool = False
 DATABASEZ_RESULT_TIMEOUT: float | None = None
 # Poll with 0.1ms, this way CPU isn't at 100%
 DATABASEZ_POLL_INTERVAL: float = 0.0001

--- a/docs/database.md
+++ b/docs/database.md
@@ -270,6 +270,14 @@ Sometimes there is a lockup. To get of the underlying issues, you can set
 
 This way lockups will raise an exception.
 
+## Debugging overwrites
+
+If you want more extensive logging when creating a custom overwrite, you can set
+
+`databasez.utils.DATABASEZ_OVERWRITE_LOGGING` to `True` to enable stack traces for import errors in debug messages.
+
+By default this is off, to not confuse people.
+
 ## Links
 
 [esmerald]: https://github.com/dymmond/esmerald

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 0.11.3
+
+### Fixed
+
+- Excessive and confusing debug logging for overwrite selection.
+- Allow `DATABASEZ_POLL_INTERVAL` overwrites.
+
 ## 0.11.2
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ check_types = "mypy -p databasez"
 [tool.hatch.envs.hatch-static-analysis]
 # disables custom ruff rules, required to align with pre-commit
 config-path = "none"
-dependencies = ["ruff==0.10.0"]
+dependencies = ["ruff==0.11.8"]
 
 
 [tool.hatch.envs.hatch-test]


### PR DESCRIPTION
Changes:
- Fix changing runtime vars via writes to utils constants
- Lock extensive overwrite logging behind knob
- update hooks